### PR TITLE
feat: Add a `python -m` entrypoint

### DIFF
--- a/api/__main__.py
+++ b/api/__main__.py
@@ -1,0 +1,6 @@
+from os import environ
+
+import uvicorn
+
+port = environ.get("PORT", "5000")
+uvicorn.run("main:app", host="0.0.0.0", port=int(port), log_level="info")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 authors = []
 description = ""
-name = ""
+name = "api"
 requires-python = ">=3.7"
 version = ""
 


### PR DESCRIPTION
## Description

Set a `name` in `pyproject.toml` and add a `__main__.py` so that the server can be started via `python -m api`. This matches one of the default configurations for deploying on [Railway](https://nixpacks.com/docs/providers/python).

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation
